### PR TITLE
Remove the unused dev dependency node-source-walk

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
         "husky": "^0.14.3",
         "jest": "^23.4.2",
         "lint-staged": "^7.2.0",
-        "node-source-walk": "^3.3.0",
         "prettier": "^1.14.0",
         "ts-jest": "^23.1.2",
         "typescript": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@ babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.17.0, babylon@^6.18.0:
+babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -2458,12 +2458,6 @@ node-pre-gyp@^0.6.39:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
-
-node-source-walk@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/node-source-walk/-/node-source-walk-3.3.0.tgz#ad18e35bfdb3d0b6f7e0e4aff1e78f846a3b8873"
-  dependencies:
-    babylon "^6.17.0"
 
 nopt@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Just noticed it's not used so it might as well go :)