### PR TITLE
Update debug to version 4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "node": ">=6.0.0"
     },
     "dependencies": {
-        "debug": "^3.1.0",
+        "debug": "^4.1.1",
         "is-url": "^1.2.4",
         "postcss": "^7.0.2",
         "postcss-values-parser": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,13 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2412,6 +2419,11 @@ mixin-deep@^1.2.0:
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 nan@^2.3.0:
   version "2.10.0"


### PR DESCRIPTION
According to the [release notes](https://github.com/visionmedia/debug/releases/tag/4.0.0) the only breaking change is dropping support for Node.js 4 and 5 which `detective-postcss` doesn't support anyway.