### PR TITLE
Upgrade postcss-values-parser to version 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "dependencies": {
         "debug": "^4.1.1",
         "is-url": "^1.2.4",
-        "postcss": "^8.1.7",
-        "postcss-values-parser": "^2.0.1"
+        "postcss": "^8.2.9",
+        "postcss-values-parser": "^5.0.0"
     },
     "devDependencies": {
         "@types/debug": "^0.0.30",

--- a/src/postcss-values-parser.d.ts
+++ b/src/postcss-values-parser.d.ts
@@ -1,26 +1,121 @@
 // incomplete declarations for the postcss-values-parser
 declare module 'postcss-values-parser' {
-    namespace parser {
-        interface Node {
-            first?: parser.Node;
-            last?: parser.Node;
-            prev?(): parser.Node;
-            type:
-                | 'atword'
-                | 'colon'
-                | 'comma'
-                | 'comment'
-                | 'func'
-                | 'number'
-                | 'operator'
-                | 'paren'
-                | 'string'
-                | 'unicoderange'
-                | 'word';
-            value: string;
-            nodes?: Node[];
-        }
+    export type Node = Root | ChildNode;
+
+    interface NodeBase {
+        next(): ChildNode | void;
+        prev(): ChildNode | void;
     }
-    function parser(str: string): { parse(): parser.Node };
-    export = parser;
+
+    interface ContainerBase extends NodeBase {
+        nodes: ChildNode[];
+        first?: ChildNode;
+        last?: ChildNode;
+    }
+
+    export interface Root extends ContainerBase {
+        type: 'root';
+    }
+
+    export type ChildNode =
+        | AtWord
+        | Comment
+        | Func
+        | Interpolation
+        | Numeric
+        | Operator
+        | Punctuation
+        | Quoted
+        | UnicodeRange
+        | Word;
+
+    export type Container = Root | Func | Interpolation;
+
+    export interface AtWord extends ContainerBase {
+        type: 'atrule';
+        parent: Container;
+        name: string;
+        params: string;
+    }
+
+    export interface Comment extends ContainerBase {
+        type: 'comment';
+        parent: Container;
+        inline: boolean;
+        text: string;
+    }
+
+    export interface Func extends ContainerBase {
+        type: 'func';
+        parent: Container;
+        isColor: boolean;
+        isVar: boolean;
+        name: string;
+        params: string;
+    }
+
+    export interface Interpolation extends ContainerBase {
+        type: 'interpolation';
+        parent: Container;
+        params: string;
+        prefix: string;
+    }
+
+    export interface Numeric extends NodeBase {
+        type: 'numeric';
+        parent: Container;
+        unit: string;
+        value: string;
+    }
+
+    export interface Operator extends NodeBase {
+        type: 'operator';
+        parent: Container;
+        value: string;
+    }
+
+    export interface Punctuation extends NodeBase {
+        type: 'punctuation';
+        parent: Container;
+        value: string;
+    }
+
+    export interface Quoted extends NodeBase {
+        type: 'quoted';
+        parent: Container;
+        quote: string;
+        value: string;
+        contents: string;
+    }
+
+    export interface UnicodeRange extends NodeBase {
+        type: 'unicodeRange';
+        parent: Container;
+        name: string;
+    }
+
+    export interface Word extends NodeBase {
+        type: 'word';
+        parent: Container;
+        isColor: boolean;
+        isHex: boolean;
+        isUrl: boolean;
+        isVariable: boolean;
+        value: string;
+    }
+
+    interface ParseOptions {
+        ignoreUnknownWords?: boolean;
+        interpolation?: boolean | InterpolationOptions;
+        variables?: VariablesOptions;
+    }
+
+    interface InterpolationOptions {
+        prefix: string;
+    }
+
+    interface VariablesOptions {
+        prefixes: string[];
+    }
+    export function parse(css: string, options?: ParseOptions): Root;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es2018"
+        "target": "es2018",
+        "paths": {
+          "*": [
+            "./src/*",
+          ]
+        },
     },
     "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,15 +1038,15 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
-  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1497,10 +1497,6 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-flatten@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
-
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1748,10 +1744,6 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
-indexes-of@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -1951,6 +1943,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-url-superb@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-4.0.0.tgz#b54d1d2499bb16792748ac967aa3ecb41a33a8c2"
+  integrity sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==
+
 is-url@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
@@ -1966,7 +1963,7 @@ is-wsl@^2.2.0:
   dependencies:
     is-docker "^2.0.0"
 
-isarray@1.0.0, isarray@^1.0.0:
+isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -2555,14 +2552,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-line-column@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
-  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
-  dependencies:
-    isarray "^1.0.0"
-    isobject "^2.0.0"
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -2822,10 +2811,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-nanoid@^3.1.16:
-  version "3.1.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
-  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
+nanoid@^3.1.22:
+  version "3.1.22"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.22.tgz#b35f8fb7d151990a8aebd5aa5015c03cf726f844"
+  integrity sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==
 
 nanomatch@^1.2.9:
   version "1.2.9"
@@ -3123,23 +3112,22 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postcss-values-parser@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
-  integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+postcss-values-parser@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-5.0.0.tgz#10c61ac3f488e4de25746b829ea8d8894e9ac3d2"
+  integrity sha512-2viDDjMMrt21W2izbeiJxl3kFuD/+asgB0CBwPEgSyhCmBnDIa/y+pLaoyX+q3I3DHH0oPPL3cgjVTQvlS1Maw==
   dependencies:
-    flatten "^1.0.2"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
+    color-name "^1.1.4"
+    is-url-superb "^4.0.0"
+    quote-unquote "^1.0.0"
 
-postcss@^8.1.7:
-  version "8.1.7"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.7.tgz#ff6a82691bd861f3354fd9b17b2332f88171233f"
-  integrity sha512-llCQW1Pz4MOPwbZLmOddGM9eIJ8Bh7SZ2Oj5sxZva77uVaotYDsYTch1WBTNu7fUY0fpWp0fdt7uW40D4sRiiQ==
+postcss@^8.2.9:
+  version "8.2.9"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.9.tgz#fd95ff37b5cee55c409b3fdd237296ab4096fba3"
+  integrity sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==
   dependencies:
-    colorette "^1.2.1"
-    line-column "^1.0.2"
-    nanoid "^3.1.16"
+    colorette "^1.2.2"
+    nanoid "^3.1.22"
     source-map "^0.6.1"
 
 prelude-ls@~1.1.2:
@@ -3209,6 +3197,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quote-unquote@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quote-unquote/-/quote-unquote-1.0.0.tgz#67a9a77148effeaf81a4d428404a710baaac8a0b"
+  integrity sha1-Z6mncUjv/q+BpNQoQEpxC6qsigs=
 
 react-is@^17.0.1:
   version "17.0.1"
@@ -3877,9 +3870,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -3889,10 +3882,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
-
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #101

Version 5 is now using PostCSS 8 so there's no more necessary duplication holding back the upgrade.

This got more complex than expected, mostly because I was trying to use the upstream types. Unfortunately there are several errors in those types. I ended up copying (& fixing) the relevant parts into the definition file. When I get around to it, I'll submit a PR to the upstream to fix the types and the extra definition file can be eliminated.
As an alternative, I could simplify the definition file similar to the previous one and remove the type narrowing code. That would preclude using the upstream types in the future.
