### PR TITLE
Move postcss to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Supports `@import` and [`@value ... from`](https://github.com/css-modules/postcss-icss-values).
 
 ```sh
-npm install detective-postcss
+npm install postcss detective-postcss
 ```
 
 It's the CSS (PostCSS dialect) counterpart to [detective](https://github.com/browserify/detective), [detective-amd](https://github.com/dependents/node-detective-amd), [detective-es6](https://github.com/dependents/node-detective-es6), [detective-sass](https://github.com/dependents/node-detective-sass), [detective-scss](https://github.com/dependents/node-detective-scss).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.38",
         "postcss-values-parser": "^6.0.2"
       },
       "devDependencies": {
@@ -18,6 +17,7 @@
         "@types/jest": "^29.5.12",
         "jest": "^29.7.0",
         "lint-staged": "^15.2.2",
+        "postcss": "^8.4.38",
         "prettier": "^3.2.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^29.1.2",
@@ -25,6 +25,9 @@
       },
       "engines": {
         "node": "^14.0.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "engines": {
     "node": "^14.0.0 || >=16.0.0"
   },
+  "peerDependencies": {
+    "postcss": "^8.4.38"
+  },
   "dependencies": {
     "is-url": "^1.2.4",
-    "postcss": "^8.4.38",
     "postcss-values-parser": "^6.0.2"
   },
   "devDependencies": {
@@ -32,6 +34,7 @@
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "lint-staged": "^15.2.2",
+    "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.1.2",


### PR DESCRIPTION
I believe this is the "proper" way nowadays, although it does require the installation of postcss.

The next version will be a major version bump so I guess we can do this change now.
