### PR TITLE
Update typescript to v6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "prettier": "^3.8.3",
         "rimraf": "^6.1.3",
         "ts-jest": "^29.4.9",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -4892,9 +4892,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "ts-jest": "^29.4.9",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "scripts": {
     "build": "rimraf ./dist && npm run compile",


### PR DESCRIPTION
I think with our current config the built code is identical so it should be safe to land in a patch release along with #316 