### PR TITLE
Tighten CI workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,9 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,9 @@ on:
 env:
   FORCE_COLOR: 2
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,35 +1,34 @@
 name: npm-publish
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 
 env:
   FORCE_COLOR: 2
+  NODE: 24
 
 jobs:
   publish:
-    # only allow on main or tags
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'dependents/node-detective-postcss'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to obtain the GitHub OIDC token used for npm provenance
+      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Use Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ env.NODE }}
           cache: npm
-      - run: npm ci
-      - id: publish
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          dry-run: ${{ github.event.action != 'published' }}
-      - if: steps.publish.outputs.type
-        run: |
-          echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This is the CSS (PostCSS dialect) counterpart to:
 
 ## Releasing
 
-- Bump the version of `package.json` to a meaningful version for the changes since the last release (we follow semver).
-- To do a dry-run of the release and what would go out in the package you can manually execute the [npm-publish](https://github.com/dependents/node-detective-postcss/actions/workflows/npm-publish.yml) workflow on the `main` branch. It will do a dry-run publish (not actually publish the new version).
-- Draft a new release in the github project - please use a tag named `vX.X.X` (where `X.X.X` is the new to-be-releases semver of the package - please add as many detail as possible to the release description.
-- Once you're ready, `Publish` the release. Publishing will trigger the [npm-publish](https://github.com/dependents/node-detective-postcss/actions/workflows/npm-publish.yml) workflow on the tag and do the actual publish to npm.
+- To preview what would be included in the package without publishing, run `npm pack --dry-run` locally.
+- Bump the version in `package.json` following [semver](https://semver.org/) with `npm version`.
+- Draft a new release on GitHub using a tag named `vX.X.X` (matching the new version). Add as much detail as possible to the release description.
+- Once you're ready, **Publish** the release. This triggers the [npm-publish](https://github.com/dependents/node-detective-postcss/actions/workflows/npm-publish.yml) workflow, which publishes the package to npm with provenance.

--- a/README.md
+++ b/README.md
@@ -80,13 +80,15 @@ This is the CSS (PostCSS dialect) counterpart to:
 - [detective-sass](https://github.com/dependents/node-detective-sass) - Sass
 - [detective-scss](https://github.com/dependents/node-detective-scss) - SCSS
 
+## Releasing
+
+1. Ensure CI is green on `main`.
+2. Preview what would be included in the package without publishing: `npm pack --dry-run`.
+3. Bump the version following [semver](https://semver.org/) (this also creates the `vX.Y.Z` tag): `npm version <patch|minor|major>`.
+4. Push the commit and tag: `git push --follow-tags`.
+5. Create (or draft) a GitHub release from that `vX.Y.Z` tag, then **Publish** it.
+6. Publishing the release triggers [npm-publish](https://github.com/dependents/node-detective-postcss/actions/workflows/npm-publish.yml) (`release.published`), which runs `npm ci` and `npm publish --provenance`.
+
 ## License
 
 [MIT](LICENSE)
-
-## Releasing
-
-- To preview what would be included in the package without publishing, run `npm pack --dry-run` locally.
-- Bump the version in `package.json` following [semver](https://semver.org/) with `npm version`.
-- Draft a new release on GitHub using a tag named `vX.X.X` (matching the new version). Add as much detail as possible to the release description.
-- Once you're ready, **Publish** the release. This triggers the [npm-publish](https://github.com/dependents/node-detective-postcss/actions/workflows/npm-publish.yml) workflow, which publishes the package to npm with provenance.


### PR DESCRIPTION
@joscha: this should improve things, but still won't work without a new limited/restricted npm token only for this package. 

Only using OIDC will probably work in the future without someone having to renew the token every 90 days.

Let me know how you want to proceed. I assume you've seen all the supply chain attacks on npm, hence why I'm trying to tighten things.